### PR TITLE
formulae_dependents: allow reading from `testing_formulae`

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -3,7 +3,7 @@
 module Homebrew
   module Tests
     class FormulaeDependents < TestFormulae
-      attr_writer :testing_formulae
+      attr_accessor :testing_formulae
 
       def run!(args:)
         (@testing_formulae - skipped_or_failed_formulae).each do |f|


### PR DESCRIPTION
This is the same change as #767.